### PR TITLE
Add conversion option for dark backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Usecases: For example if you have a scanned document/book page that contains cod
 ## Usage
 
 The bot is on telegram (might be down, depending on where/if I host it) @GivesTextFromImageBot
+- `/start` to start the bot
+- `/help` for help
+- `/convert` as a caption on an image with a light backgroud and black text -> gives the text in the image (with some margin of error)
+- `/convert_dark` as a caption on an image with a dark background with some mad polychromatic mess of letters -> gives the text in the image (with some margin of error)
 
 ## Other
 
-Requires PyTessaract installed on hostmachine
+Requires PyTessaract installed on hostmachine if you aim to run it without docker-compose

--- a/src/main.py
+++ b/src/main.py
@@ -6,16 +6,16 @@ from telegram import Bot,Update
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 import os
 
-def processImage(image_path: str) -> str:
-    
+def processImage(image_path: str) -> str:    
+    image = Image.open(image_path)
+    text = pytesseract.image_to_string(image)
+    return text
+
+def processDarkImage(image_path: str) -> str:
     image = Image.open(image_path)
     image = ImageOps.invert(image.convert('RGB'))
     text = pytesseract.image_to_string(image)
-
-    print(text[:-1])
     return text
-
-
 
 # Bot stuff
 from telegram import __version__ as TG_VER
@@ -59,11 +59,10 @@ async def start_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
 
 # When /help is called
 async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    await update.message.reply_text("Just send me a screenshot of text with the 'convert' as a caption, that's all I do")
+    await update.message.reply_text("Just send me a screenshot of text with the /convert as a caption, that's all I do")
 
 # When image is sent with 'convert' as caption
 async def convert_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        logger.info('We in the convert now!')
         if update.message:
             if update.message.document and update.message.document.mime_type.__eq__('image/png'):
                 logger.info('Handling image...')
@@ -75,16 +74,29 @@ async def convert_command(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 logger.info('Got this: %s', result)
                 await update.message.reply_text(result)
             else: 
-                await update.message.reply_text('beep boop, I am a bot designed for OCR tasks only')
+                await update.message.reply_text('Looks like you did not provide an image with that command there bud, what am I supposed to convert? (/help for help)')
+
+# When image is sent with 'convert_dark' as caption, this is for images with a dark background
+async def convert_dark_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if update.message:
+            if update.message.document and update.message.document.mime_type.__eq__('image/png'):
+                logger.info('Handling image...')
+                file_id = update.message.document.file_id
+                new_file = await context.bot.get_file(file_id)
+                await new_file.download_to_drive(custom_path='assets/image_to_process.jpg')
+            
+                result = processDarkImage(r'assets/image_to_process.jpg')
+                logger.info('Got this: %s', result)
+                await update.message.reply_text(result)
+            else: 
+                await update.message.reply_text('Looks like you did not provide an image with that command there bud, what am I supposed to convert? (/help for help)')
 
 # When someone inputs some random stuff
 async def unkown(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     await update.message.reply_text('AAAAAUGH I am a bot designed for OCR tasks ONLY (/help for help)')
 
 def main() -> None:
-
     """Run the bot."""
-
     # Here we use the `async with` syntax to properly initialize and shutdown resources.
     BOT_TOKEN = os.environ.get('BOT_TOKEN')
 
@@ -92,8 +104,12 @@ def main() -> None:
 
     application.add_handler(CommandHandler("start", start_command))
     application.add_handler(CommandHandler("help", help_command))
+
+    application.add_handler(CommandHandler("convert_dark",convert_dark_command))
+    application.add_handler(MessageHandler(filters.Document.MimeType('image/png') & filters.CaptionRegex(r'convert_dark'),convert_dark_command))
+    
+    application.add_handler(CommandHandler("convert",convert_command))
     application.add_handler(MessageHandler(filters.Document.MimeType('image/png') & filters.CaptionRegex(r'convert'),convert_command))
-    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, unkown))
 
     application.run_polling()
             


### PR DESCRIPTION
Made a separate command for converting images with dark backgrounds like this one for example: 
![image](https://user-images.githubusercontent.com/55868268/218332146-0ccb7af8-7346-4bbb-b2d5-a4d6c5c8ce54.png)
Played around with some image pre processing and config flags for tesseract buuut that will have to be for another day.